### PR TITLE
moved authorization to an app to enable testing with tokens

### DIFF
--- a/trading_api/urls.py
+++ b/trading_api/urls.py
@@ -16,19 +16,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-    TokenVerifyView
-)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/1/", include("website.urls")),
-    path('auth/token/', TokenObtainPairView.as_view(),
-         name='token_obtain_pair'),
-    path('auth/token/refresh/', TokenRefreshView.as_view(),
-         name='token_refresh'),
-    path('auth/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     path("user/", include("users.urls")),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,10 +1,20 @@
 from django.urls import path
 
 from users import views
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView
+)
 
 app_name = 'users'
 
 urlpatterns = [
     path('register/', views.RegisterUser.as_view(), name='register'),
     path('update/', views.UpdateUser.as_view(), name='update'),
+    path('token/', TokenObtainPairView.as_view(),
+         name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(),
+         name='token_refresh'),
+    path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
 ]


### PR DESCRIPTION
I had some issues using the test apiclient to call the token endpoints when it was in the trading_api urls. moved it to user app 