### PR TITLE
Auction authorization

### DIFF
--- a/website/api_urls/auction.py
+++ b/website/api_urls/auction.py
@@ -5,7 +5,6 @@ from website.views import (
     MemberAuctionList,
     CategoryAuctionList,
     SubcategoryAuctionList,
-    AuctionDeleteByUser,
 )
 
 urlpatterns = [
@@ -20,23 +19,19 @@ urlpatterns = [
         name="auction-detail",
     ),
     path(
-        "User/<str:username>",
+        "user/<str:username>",
         MemberAuctionList.as_view({"get": "list"}),
         name="member-auction-list",
     ),
     path(
-        "Category/<slug:name>",
+        "category/<slug:name>",
         CategoryAuctionList.as_view(),
         name="category-auction-list",
     ),
     path(
-        "Subcategory/<slug:subcategory_name>",
+        "subcategory/<slug:subcategory_name>",
         SubcategoryAuctionList.as_view(),
         name="subcategory-auction-list",
     ),
-    path(
-        "delete/User/<str:username>",
-        AuctionDeleteByUser.as_view(),
-        name="auction-delete-by-user",
-    ),
+
 ]

--- a/website/models/member.py
+++ b/website/models/member.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save  # , pre_save
 from django.dispatch import receiver
 
 
@@ -19,6 +19,16 @@ class Member(models.Model):
 User._meta.get_field('email')._unique = True
 User._meta.get_field('email').blank = False
 User._meta.get_field('email').null = False
+
+# this sets user as inactive. Used for email verification on registration
+
+# @receiver(pre_save, sender=User)
+# def set_new_user_inactive(sender, instance, **kwargs):
+#     if instance._state.adding is True:
+#         print("Creating Inactive User")
+#         instance.is_active = False
+#     else:
+#         print("Updating User Record")
 
 
 @receiver(post_save, sender=User)

--- a/website/serializer/auction.py
+++ b/website/serializer/auction.py
@@ -53,15 +53,6 @@ class AuctionListSerializer(HyperlinkedModelSerializer):
 
 class AuctionCreateSerializer(ModelSerializer):
 
-    def create(self, validated_data):
-        subcategory = validated_data.get("subcategory")
-        subcategory_object = Subcategory.objects.filter(
-            subcategory_name=subcategory).values("category")
-        category = Category.objects.filter(
-            id=subcategory_object[0]["category"])
-
-        return Auction.objects.create(**validated_data, category=category[0])
-
     class Meta:
         model = Auction
         fields = (
@@ -74,6 +65,18 @@ class AuctionCreateSerializer(ModelSerializer):
             "startTime",
             "endTime",
         )
+        read_only_fields = ("auctionOwner",)
+
+    def create(self, validated_data):
+        subcategory = validated_data.get("subcategory")
+        auctionOwner = self.context["request"].user
+        subcategory_object = Subcategory.objects.filter(
+            subcategory_name=subcategory).values("category")
+        category = Category.objects.filter(
+            id=subcategory_object[0]["category"])
+
+        return Auction.objects.create(**validated_data, category=category[0],
+                                      auctionOwner=auctionOwner)
 
 
 class AuctionDetailSerializer(ModelSerializer):

--- a/website/tests/__init__.py
+++ b/website/tests/__init__.py
@@ -1,1 +1,1 @@
-from .test_model import TestModel
+from .test_auction import *

--- a/website/tests/test_auction.py
+++ b/website/tests/test_auction.py
@@ -1,0 +1,317 @@
+from django.contrib.auth.models import User
+from website.models import Category, Subcategory, Auction
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+
+def create_dummy_auctions():
+    """Create dummy auctions for testing"""
+    # make sure there are always 2 users
+    User.objects.create_user(
+        username="auctionOwner1", password="testpassword",
+        email="auctionOwner1@example.com")
+    User.objects.create_user(
+        username="auctionOwner2", password="testpassword",
+        email="auctionOwner2@example.com")
+
+    Category.objects.create(name="Vehicle")
+    Subcategory.objects.create(
+        category=Category.objects.get(id=1),
+        subcategory_name="Car")
+    Category.objects.create(name="Electronics")
+    Subcategory.objects.create(category=Category.objects.get(id=2),
+                               subcategory_name="Phone")
+    for i in range(5):
+        Auction.objects.create(
+            auctionOwner=User.objects.get(id=1),
+            title="Test Auction " + str(i),
+            description="This is a test auction " + str(i),
+            category=Category.objects.get(id=1),
+            subcategory=Subcategory.objects.get(id=1),
+            startingPrice=100 + i,
+            buyOutPrice=200 + i,
+            endTime="2020-12-31T00:00:00Z",
+        )
+    for i in range(5):
+        Auction.objects.create(
+            auctionOwner=User.objects.get(id=2),
+            title="Test Auction " + str(i),
+            description="This is a test auction " + str(i),
+            category=Category.objects.get(id=2),
+            subcategory=Subcategory.objects.get(id=2),
+            startingPrice=100 + i,
+            buyOutPrice=200 + i,
+            endTime="2020-12-31T00:00:00Z",
+        )
+
+
+def get_token(username, password):
+    """Get token for user"""
+    client = APIClient()
+    url = reverse("token_obtain_pair")
+    payload = {"username": username, "password": password}
+    response = client.post(url, payload)
+    return response.data["access"]
+
+
+class AuctionListCreateTest(APITestCase):
+    """Test for the AuctionList view"""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        Category.objects.create(name="TestCategory")
+        Subcategory.objects.create(
+            category=Category.objects.get(id=1),
+            subcategory_name="TestSubcategory")
+        self.url = reverse("auction-list")
+
+    def test_create_and_list_auction(self):
+        """Test creating an auction"""
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "title": "Test Auction",
+            "description": "This is a test auction",
+            "subcategory": 1,
+            "startingPrice": 100,
+            "buyOutPrice": 200,
+            "endTime": "2020-12-31T00:00:00Z"
+        }
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["title"], payload["title"])
+        self.assertEqual(response.data["description"], payload["description"])
+        self.assertEqual(response.data["subcategory"], payload["subcategory"])
+        self.assertEqual(
+            response.data["startingPrice"], '100.00')
+        self.assertEqual(response.data["buyOutPrice"], '200.00')
+        self.assertEqual(response.data["endTime"], payload["endTime"])
+        # mass create auctions
+        create_dummy_auctions()
+        # now check auction listing
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 11)
+        # make sure category was set correctly from subcategory
+        self.assertEqual(
+            response.data[0]["category"],
+            'http://testserver/api/1/category/TestCategory')
+
+    def test_unathorized(self):
+        payload = {
+            "title": "Test Auction",
+            "description": "This is a test auction",
+            "subcategory": 1,
+            "startingPrice": 100,
+            "buyOutPrice": 200,
+            "endTime": "2020-12-31T00:00:00Z"
+        }
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # now check auction listing
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # should be empty
+        self.assertEqual(len(response.data), 0)
+
+
+class AuctionDetailTest(APITestCase):
+    """Test for the AuctionDetail view"""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword",
+            email="test1@example.com")
+        # create second user
+        self.user2 = User.objects.create_user(
+            username="testuser2", password="testpassword2",
+            email="test2@example.com")
+        create_dummy_auctions()
+
+    def test_get_auction(self):
+        """Test getting an auction"""
+        url = reverse("auction-detail", kwargs={"auctionID": 1})
+        # anyone should be able to get auction details
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_auction(self):
+        """Test updating an auction"""
+        url = reverse("auction-detail", kwargs={"auctionID": 1})
+        # auctions should not be able to be updated
+        response = self.client.patch(url, {"title": "New Title"})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        response = self.client.put(url, {"title": "New Title"})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # even if you own the auction
+        user1_token = get_token("testuser", "testpassword")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + user1_token)
+        response = self.client.patch(url, {"title": "New Title"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        response = self.client.put(url, {"title": "New Title"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_auction(self):
+        """Test deleting an auction"""
+        url = reverse("auction-detail", kwargs={"auctionID": 1})
+        # auctions should not be able to be deleted
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # even if you own the auction
+        user1_token = get_token("testuser", "testpassword")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + user1_token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_edit_auction(self):
+        """Test staff editing an auction"""
+        url = reverse("auction-detail", kwargs={"auctionID": 1})
+        # create staff user
+        User.objects.create_user(
+            username="staff", password="testpassword",
+            email="staff@example.com", is_staff=True
+        )
+
+        response = self.client.get(url)
+        self.assertEqual(response.data["title"], "Test Auction 0")
+
+        # staff should be able to edit any auction
+        staff_token = get_token("staff", "testpassword")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + staff_token)
+
+        payload = {"title": "New Title"}
+        self.client.patch(url, payload)
+        response = self.client.get(url)
+        self.assertEqual(response.data["title"], payload["title"])
+
+        self.client.delete(url)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class CategoryAuctionListTest(APITestCase):
+    """Test for the CategoryAuctionList view"""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword",
+            email="test@example.com")
+        create_dummy_auctions()
+
+    def test_get_category_auctions(self):
+        """Test getting auctions by category"""
+        url = reverse("category-auction-list", kwargs={"name": "Vehicle"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+        url = reverse("category-auction-list", kwargs={"name": "Electronics"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+
+class SubcategoryAuctionListTest(APITestCase):
+    """Test for the SubcategoryAuctionList view"""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword",
+            email="test@example.com")
+        create_dummy_auctions()
+
+    def test_get_subcategory_auctions(self):
+        """Test getting auctions by subcategory"""
+        url = reverse("subcategory-auction-list",
+                      kwargs={"subcategory_name": "Car"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+        url = reverse("subcategory-auction-list",
+                      kwargs={"subcategory_name": "Phone"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+
+class MemberAuctionListTest(APITestCase):
+    """Test for the MemberAuctionList view"""
+
+    def setUp(self):
+        self.client = APIClient()
+        create_dummy_auctions()
+
+    def test_get_member_auctions(self):
+        """Test getting auctions by member"""
+        url = reverse("member-auction-list",
+                      kwargs={"username": "auctionOwner1"})
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+        url = reverse("member-auction-list",
+                      kwargs={"username": "auctionOwner2"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+    def test_delete_member_auctions(self):
+        """Test deleting auctions by member"""
+        url = reverse("member-auction-list",
+                      kwargs={"username": "auctionOwner1"})
+
+        # there exists auctions by auctionOwner1
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+        # unauthorized
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        # authenticate as auctionOwner1
+        user1_token = get_token("auctionOwner1", "testpassword")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + user1_token)
+        response = self.client.delete(url)
+
+        # should be forbidden
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # no auctions should be deleted
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+    def test_staff_delete_member_auctions(self):
+        """Test staff deleting auctions by member"""
+        url = reverse("member-auction-list",
+                      kwargs={"username": "auctionOwner1"})
+
+        User.objects.create_user(
+            username="staff", password="testpassword",
+            email="staff@example.com", is_staff=True
+        )
+
+        # there exists auctions by auctionOwner1
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+        # authenticate as staff
+        staff_token = get_token("staff", "testpassword")
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + staff_token)
+        response = self.client.delete(url)
+
+        # should be no content
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # no auctions should be deleted
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)

--- a/website/tests/test_model.py
+++ b/website/tests/test_model.py
@@ -1,6 +1,0 @@
-from django.test import TestCase
-
-
-class TestModel(TestCase):
-    def test_model(self):
-        self.assertEqual(1, 1)

--- a/website/views/auction.py
+++ b/website/views/auction.py
@@ -5,13 +5,24 @@ from website.serializer import (AuctionListSerializer,
                                 AuctionCreateSerializer,)
 
 from website.models import Auction
+from rest_framework.permissions import BasePermission
 
 # Auction views
+
+
+class AuctionPermission(BasePermission):
+
+    def has_permission(self, request, view):
+        if view.action == "list":
+            return True
+        elif view.action == "create":
+            return request.user.is_authenticated
 
 
 class AuctionList(ModelViewSet):
     queryset = Auction.objects.all()
     serializer_class = AuctionListSerializer
+    permission_classes = (AuctionPermission,)
 
     def get_serializer_class(self):
         if self.action == "create":

--- a/website/views/auction.py
+++ b/website/views/auction.py
@@ -1,4 +1,5 @@
-from rest_framework import generics
+from rest_framework import generics, status
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 from website.serializer import (AuctionListSerializer,
                                 AuctionDetailSerializer,
@@ -11,7 +12,6 @@ from rest_framework.permissions import BasePermission
 
 
 class AuctionPermission(BasePermission):
-
     def has_permission(self, request, view):
         if view.action == "list":
             return True
@@ -19,10 +19,30 @@ class AuctionPermission(BasePermission):
             return request.user.is_authenticated
 
 
+class AuctionEditPermission(BasePermission):
+    def has_permission(self, request, view):
+        # staff and superuser can do anything
+        if request.user.is_staff or request.user.is_superuser:
+            return True
+        if request.method == "GET":
+            return True
+        return False  # you should not be able to edit any auctions
+
+    def has_object_permission(self, request, view, obj):
+        # staff and superuser can do anything
+        if request.user.is_staff or request.user.is_superuser:
+            return True
+        if request.method == "GET":
+            return True
+        return False  # you should not be able to edit any auctions
+        # if you want to be able to edit your auctions, use this:
+        # return obj.auctionOwner == request.user
+
+
 class AuctionList(ModelViewSet):
     queryset = Auction.objects.all()
     serializer_class = AuctionListSerializer
-    permission_classes = (AuctionPermission,)
+    permission_classes = (AuctionPermission, )
 
     def get_serializer_class(self):
         if self.action == "create":
@@ -31,6 +51,8 @@ class AuctionList(ModelViewSet):
 
 
 class AuctionDetail(generics.RetrieveUpdateDestroyAPIView):
+    permission_classes = (AuctionEditPermission, )
+
     queryset = Auction.objects.all()
     serializer_class = AuctionDetailSerializer
     lookup_field = "auctionID"
@@ -52,10 +74,17 @@ class SubcategoryAuctionList(generics.ListAPIView):
         return Auction.objects.filter(subcategory__subcategory_name=subcat)
 
 
-class AuctionDeleteByUser (generics.DestroyAPIView):
+class MemberAuctionList(ModelViewSet):
     queryset = Auction.objects.all()
-    serializer_class = AuctionDetailSerializer
+    serializer_class = AuctionListSerializer
+    permission_classes = (AuctionEditPermission, )
 
     def get_queryset(self):
         username = self.kwargs["username"]
         return Auction.objects.filter(auctionOwner__username=username)
+
+    def delete(self, request, *args, **kwargs):
+        username = self.kwargs["username"]
+        resp_data = Auction.objects.filter(
+            auctionOwner__username=username).delete()
+        return Response(resp_data, status=status.HTTP_204_NO_CONTENT)

--- a/website/views/member.py
+++ b/website/views/member.py
@@ -1,12 +1,8 @@
-from rest_framework import status
-from rest_framework.response import Response
 from rest_framework import generics
-from rest_framework.viewsets import ModelViewSet
-from website.serializer import (AuctionListSerializer,
-                                UserListSerializer,
-                                UserDetailSerializer,
-                                )
-from website.models import Auction
+from website.serializer import (
+    UserListSerializer,
+    UserDetailSerializer,
+)
 from django.contrib.auth.models import User
 
 
@@ -19,19 +15,3 @@ class MemberDetail(generics.RetrieveAPIView):
     queryset = User.objects.all()
     serializer_class = UserDetailSerializer
     lookup_field = "username"
-
-
-class MemberAuctionList(ModelViewSet):
-    queryset = Auction.objects.all()
-    serializer_class = AuctionListSerializer
-
-    def get_queryset(self):
-        username = self.kwargs["username"]
-        return Auction.objects.filter(auctionOwner__username=username)
-
-    def delete(self, request, *args, **kwargs):
-        username = self.kwargs["username"]
-        resp_data = Auction.objects.filter(
-            auctionOwner__username=username).delete()
-        print(resp_data)
-        return Response(resp_data, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
fixes #22 

right now only staff and superusers can edit auctions. this is to prevent users from making an auction then editing it to mislead a bidder